### PR TITLE
Add support for the dailyRotateFile transport and improve pagination

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,16 +20,26 @@ module.exports = function (app, logger) {
         var page = req.params.page || 1,
             itemsOnPage = 30;
 
+        page = parseInt(page);
+
+        var level = req.query.level || '';
+
         wld.list({
             limit: itemsOnPage,
-            offset: (page - 1) * itemsOnPage
+            offset: (page - 1) * itemsOnPage,
+            level: level
         }).then(function (logs) {
             var pagesCount = Math.floor(wld.count / itemsOnPage) + (wld.count % itemsOnPage === 0 ? 0 : 1);
 
+            var start = Math.max(1, page - 2);
+            var end = Math.min(pagesCount, start + 4);
+
             res.send(jade.renderFile(__dirname + '/views/logs.jade', {
                 logs: logs,
-                pages: _.range(1, pagesCount + 1),
-                currentPage: page
+                pages: _.range(start, end + 1),
+                currentPage: page,
+                lastPage: pagesCount,
+                level: level
             }, null));
         });
 

--- a/app.js
+++ b/app.js
@@ -8,6 +8,10 @@ module.exports = function (app, logger) {
 
     wld = new (require('./lib/wld'))(logger);
 
+    app.get('/', function(req, res) {
+        res.redirect('/logs/1');
+    });
+
     app.get('/logs', function(req, res) {
         res.redirect('/logs/1');
     });
@@ -24,7 +28,8 @@ module.exports = function (app, logger) {
 
             res.send(jade.renderFile(__dirname + '/views/logs.jade', {
                 logs: logs,
-                pages: _.range(1, pagesCount + 1)
+                pages: _.range(1, pagesCount + 1),
+                currentPage: page
             }, null));
         });
 

--- a/lib/wld.js
+++ b/lib/wld.js
@@ -4,7 +4,22 @@ var Promise = require('bluebird'),
     _ = require('lodash');
 
 function WLD(logger) {
-    this.transport = logger.transports[_.keys(logger.transports)[0]];
+    var self = this;
+
+    var supportedKeys = ['dailyRotateFile', 'file']
+    var transportFound = supportedKeys.some(function (key) {
+        if (logger.transports[key]) {
+            self.transport = logger.transports[key];
+            return true;
+        }
+
+        return false;
+    });
+
+    if (!transportFound) {
+        throw "No file or dailyRotateFile found in the transports list";
+    }
+
     this.count = null;
 }
 
@@ -21,8 +36,7 @@ WLD.prototype.list = function (options) {
     options.offset = options.offset || 0;
 
     return new Promise(function (resolve, reject) {
-
-        self.transport.query({}, function (error, logs) {
+        self.transport.query({rows: 99999, start: 0}, function (error, logs) {
             if (error) {
                 return reject(error);
             }

--- a/lib/wld.js
+++ b/lib/wld.js
@@ -6,6 +6,8 @@ var Promise = require('bluebird'),
 function WLD(logger) {
     var self = this;
 
+    this.levels = logger.levels;
+
     var supportedKeys = ['dailyRotateFile', 'file']
     var transportFound = supportedKeys.some(function (key) {
         if (logger.transports[key]) {
@@ -34,12 +36,17 @@ WLD.prototype.list = function (options) {
 
     options.limit = options.limit || 50;
     options.offset = options.offset || 0;
+    options.level = self.levels[options.level] || 1e10;
 
     return new Promise(function (resolve, reject) {
         self.transport.query({rows: 99999, start: 0}, function (error, logs) {
             if (error) {
                 return reject(error);
             }
+
+            logs = _.filter(logs, function (entry) {
+                return self.levels[entry.level] <= options.level;
+            });
 
             self.count = logs.length;
             logs = logs.splice(options.offset, options.limit);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-logs-display",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node.js module for express, main purpose of that module is make easy access to winston logs",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-logs-display",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node.js module for express, main purpose of that module is make easy access to winston logs",
   "main": "app.js",
   "scripts": {

--- a/views/logs.jade
+++ b/views/logs.jade
@@ -46,5 +46,5 @@ html(lang="en")
                 nav
                     ul.pagination
                         each page in pages
-                            li
+                            li(class=page == currentPage ? "active" : "")
                                 a(href='/logs/' + page)= page

--- a/views/logs.jade
+++ b/views/logs.jade
@@ -20,6 +20,7 @@ html(lang="en")
     body
         div.container
             h1 Logs
+            pre To apply a filter just append ?level=<i>minimum_level</i> to the url!
             table.table.table-condensed
                 thead
                     tr
@@ -45,6 +46,18 @@ html(lang="en")
             if pages.length > 1
                 nav
                     ul.pagination
+                        li(class=currentPage == 1 ? "disabled" : "")
+                            a(href=currentPage == 1 ? '#' : '/logs/1?level=' + level)= '< First'
+
+                        li(class=currentPage == 1 ? "disabled" : "")
+                            a(href=currentPage == 1 ? '#' : '/logs/' + (currentPage - 1) + '?level=' + level)= '<'
+
                         each page in pages
                             li(class=page == currentPage ? "active" : "")
-                                a(href='/logs/' + page)= page
+                                a(href='/logs/' + page + '?level=' + level)= page
+
+                        li(class=currentPage == lastPage ? "disabled" : "")
+                            a(href=currentPage == lastPage ? '#' : '/logs/' + (currentPage + 1) + '?level=' + level)= '>'
+
+                        li(class=currentPage == lastPage ? "disabled" : "")
+                            a(href=currentPage == lastPage ? '#' : '/logs/' + lastPage + '?level=' + level)= 'Last >'


### PR DESCRIPTION
With newer versions of Winston only 10 rows were returned using queries
without any options. Now up to 10k lines are read and processed.

The pagination has been improved too, and now highlights which page is
being shown.